### PR TITLE
Adding more seed data

### DIFF
--- a/data/seeds/002_cities.js
+++ b/data/seeds/002_cities.js
@@ -15,7 +15,6 @@ exports.seed = function (knex) {
           livability: '85',
           profile_id: '00ulthapbErVUwVJy4x6',
         },
-
         {
           city: 'Atlanta',
           state: 'Georgia',
@@ -27,7 +26,6 @@ exports.seed = function (knex) {
           livability: '85',
           profile_id: '00ulthapbErVUwVJy4x6',
         },
-
         {
           city: 'Rancho Cucamonga',
           state: 'California',
@@ -39,7 +37,6 @@ exports.seed = function (knex) {
           livability: '85',
           profile_id: '00ulthapbErVUwVJy4x6',
         },
-
         {
           city: 'La Jolla',
           state: 'California',
@@ -60,9 +57,8 @@ exports.seed = function (knex) {
           diversity_index: '64',
           walkability: '44',
           livability: '87',
-          profile_id: 'k43c1w9h0g5q5aoah0x4',
+          profile_id: '00ulthapbErVUwVJy4x6',
         },
-        
         {
           city: 'Austin',
           state: 'Texas',
@@ -72,9 +68,8 @@ exports.seed = function (knex) {
           diversity_index: '56',
           walkability: '66',
           livability: '87',
-          profile_id: 'k43c1w9h0g5q5aoah0x4',
+          profile_id: '00ulthapbErVUwVJy4x6',
         },
-        
         {
           city: 'Des Moine',
           state: 'Iowa',
@@ -84,7 +79,7 @@ exports.seed = function (knex) {
           diversity_index: '52',
           walkability: '10',
           livability: '90',
-          profile_id: 'k43c1w9h0g5q5aoah0x4',
+          profile_id: '00ulthapbErVUwVJy4x6',
         },
       ]);
     });

--- a/data/seeds/002_cities.js
+++ b/data/seeds/002_cities.js
@@ -27,6 +27,7 @@ exports.seed = function (knex) {
           livability: '85',
           profile_id: '00ulthapbErVUwVJy4x6',
         },
+
         {
           city: 'Rancho Cucamonga',
           state: 'California',
@@ -38,6 +39,7 @@ exports.seed = function (knex) {
           livability: '85',
           profile_id: '00ulthapbErVUwVJy4x6',
         },
+
         {
           city: 'La Jolla',
           state: 'California',
@@ -48,6 +50,41 @@ exports.seed = function (knex) {
           walkability: '5.0',
           livability: '75',
           profile_id: '00ulthapbErVUwVJy4x6',
+        },
+        {
+          city: 'Tampa',
+          state: 'Florida',
+          rental_price: '1300',
+          crime: 'low',
+          air_quality_index: 'low',
+          diversity_index: '64',
+          walkability: '44',
+          livability: '87',
+          profile_id: 'k43c1w9h0g5q5aoah0x4',
+        },
+        
+        {
+          city: 'Austin',
+          state: 'Texas',
+          rental_price: '1900',
+          crime: 'medium',
+          air_quality_index: 'low',
+          diversity_index: '56',
+          walkability: '66',
+          livability: '87',
+          profile_id: 'k43c1w9h0g5q5aoah0x4',
+        },
+        
+        {
+          city: 'Des Moine',
+          state: 'Iowa',
+          rental_price: '900',
+          crime: 'low',
+          air_quality_index: 'low',
+          diversity_index: '52',
+          walkability: '10',
+          livability: '90',
+          profile_id: 'k43c1w9h0g5q5aoah0x4',
         },
       ]);
     });


### PR DESCRIPTION
Added more seed data. I figured out that the city seed data file needs to have the "test001" user as the profile_id for all cities that are added. Test001 user is hardcoded in the profile seed data. The rest of the users are randomly generated when the seeds are re-run. When I ran this with a profile_id that did not exist, the City table was corrupted and no data was visible in the database. I changed everything to test001 profile_id in the city seed data file and everything worked again.